### PR TITLE
refactor: update package.json and vite.config.ts to use terser for mi…

### DIFF
--- a/BUILD_FIX.md
+++ b/BUILD_FIX.md
@@ -1,0 +1,30 @@
+# Install Terser (optional - for better compression)
+
+If you want to use Terser instead of esbuild for minification:
+
+```bash
+npm install --save-dev terser
+```
+
+Then update vite.config.ts:
+
+```typescript
+build: {
+  minify: 'terser',
+  terserOptions: {
+    compress: {
+      drop_console: true,
+      drop_debugger: true
+    }
+  }
+}
+```
+
+## Current Configuration (Recommended)
+
+The current setup uses esbuild which is:
+- ✅ Faster build times
+- ✅ No additional dependencies 
+- ✅ Built into Vite
+- ✅ Good minification results
+- ✅ Better for CI/CD environments

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "globals": "^16.2.0",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
+        "terser": "^5.43.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.1",
         "vite": "^6.3.5"
@@ -1054,6 +1055,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2040,6 +2052,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -4150,6 +4169,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4158,6 +4187,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -4363,6 +4403,32 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "globals": "^16.2.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
+    "terser": "^5.43.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1",
     "vite": "^6.3.5"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,15 +19,9 @@ export default defineConfig({
     // Reduce chunk size warnings
     chunkSizeWarningLimit: 1000,
     // Enable sourcemaps for production debugging
-    sourcemap: 'hidden',
-    // Minify for smaller bundle size
-    minify: 'terser',
-    terserOptions: {
-      compress: {
-        drop_console: true,
-        drop_debugger: true
-      }
-    }
+    sourcemap: false,
+    // Use esbuild for faster minification (default in Vite)
+    minify: 'esbuild'
   },
   
   optimizeDeps: {


### PR DESCRIPTION
This pull request updates the project's build configuration to use esbuild for minification by default, while providing optional instructions for using Terser. The changes simplify the build process, improve build speed, and clarify the recommended setup.

**Build configuration improvements:**

* Updated `vite.config.ts` to use esbuild for faster and simpler minification, removed custom Terser options, and set `sourcemap` to `false` for production builds.
* Added Terser as a dev dependency in `package.json` to allow optional use for minification.

**Documentation updates:**

* Added a new section in `BUILD_FIX.md` explaining how to install and configure Terser for minification, and clarified that esbuild is the recommended and default minifier.…nification and add new dependencies